### PR TITLE
Add SOLID violation examples for OCP, ISP and LSP

### DIFF
--- a/demo-target.Api/InterfaceSegregationViolation.cs
+++ b/demo-target.Api/InterfaceSegregationViolation.cs
@@ -1,0 +1,19 @@
+public interface IMultiFunctionDevice {
+    void Print();
+    void Scan();
+    void Fax();
+}
+
+public class SimplePrinter : IMultiFunctionDevice {
+    public void Print() {
+        Console.WriteLine("Printing");
+    }
+
+    public void Scan() {
+        throw new NotImplementedException(); // ISP violation
+    }
+
+    public void Fax() {
+        throw new NotImplementedException(); // ISP violation
+    }
+}

--- a/demo-target.Api/LiskovViolation.cs
+++ b/demo-target.Api/LiskovViolation.cs
@@ -1,0 +1,11 @@
+public class Bird {
+    public virtual void Fly() {
+        Console.WriteLine("Bird is flying");
+    }
+}
+
+public class Penguin : Bird {
+    public override void Fly() {
+        throw new NotSupportedException("Penguins can't fly"); // LSP violation
+    }
+}

--- a/demo-target.Api/OpenClosedViolation.cs
+++ b/demo-target.Api/OpenClosedViolation.cs
@@ -1,0 +1,29 @@
+public class ShapeAreaCalculator {
+    public double CalculateArea(object shape) {
+        if (shape is Circle circle) {
+            return Math.PI * circle.Radius * circle.Radius;
+        } else if (shape is Rectangle rectangle) {
+            return rectangle.Width * rectangle.Height;
+        } else if (shape is Triangle triangle) {
+            return 0.5 * triangle.Base * triangle.Height;
+        }
+
+        throw new ArgumentException("Unknown shape");
+    }
+}
+
+// OCP violation: adding new shapes requires modifying this class
+
+public class Circle {
+    public double Radius { get; set; }
+}
+
+public class Rectangle {
+    public double Width { get; set; }
+    public double Height { get; set; }
+}
+
+public class Triangle {
+    public double Base { get; set; }
+    public double Height { get; set; }
+}


### PR DESCRIPTION
## Summary
- add shape area calculator requiring edits for new shapes to violate the Open/Closed Principle
- create overly broad multi-function interface forcing SimplePrinter to implement unused members
- add Bird/Penguin classes where Penguin breaks substitutability to show Liskov violation

## Testing
- `dotnet build demo-target.Api` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abec94031883339037a521f6c9a866